### PR TITLE
Fix: SIGPIPE crash with Linux update

### DIFF
--- a/Source/TaurusTLS.pas
+++ b/Source/TaurusTLS.pas
@@ -235,9 +235,9 @@ uses
   Windows,
   {$ENDIF}
 {$ENDIF}
-{$IF Defined(Linux) or Defined(Android)}
+{$IFDEF SIGPIPE_MASK}
   Posix.Signal,
-{$IFEND}
+{$ENDIF}
   Classes,
   IdCTypes,
   IdGlobal,
@@ -1288,9 +1288,6 @@ type
     fSSLContext: TTaurusTLSContext;
     fHostName: String;
     fVerifyHostname: Boolean;
-{$IF Defined(Linux) or Defined(Android)}
-     FSigSet: sigset_t;
-{$IFEND}
     function GetSSLProtocolVersion: TTaurusTLSSSLVersion;
     function GetSSLProtocolVersionStr: string;
     function GetPeerCert: TTaurusTLSX509;
@@ -1298,9 +1295,6 @@ type
     function GetCipher: TTaurusTLSCipher;
     function GetVerifyHostname: Boolean;
     procedure SetVerifyHostName(const Value: Boolean);
-{$IF Defined(Linux) or Defined(Android)}
-    procedure DisableSigPipe;
-{$IFEND}
   public
     /// <summary>
     /// Creates a new instance of TTaurusTLSSocket.
@@ -4858,6 +4852,20 @@ begin
   Result.VerifyHostname := VerifyHostname;
 end;
 
+// SIGPIPE crash mitigation in Linux
+procedure SetSigpipeMask; {$IFDEF USE_INLINE}inline; {$ENDIF}
+{$IFDEF SIGPIPE_MASK}
+var
+  LSigSet: sigset_t;
+{$ENDIF}
+begin
+{$IFDEF SIGPIPE_MASK}
+  sigemptyset(LSigSet);
+  sigaddset(LSigSet, SIGPIPE);
+  pthread_sigmask(SIG_BLOCK, @LSigSet, nil);
+{$ENDIF}
+end;
+
 { TTaurusTLSSocket }
 
 constructor TTaurusTLSSocket.Create(AParent: TObject);
@@ -4909,9 +4917,9 @@ var
 begin
   Assert(fSSL = nil);
   Assert(fSSLContext <> nil);
-{$IF Defined(Linux) or Defined(Android)}
-  DisableSigPipe;
-{$IFEND}
+
+  SetSigpipeMask;  // SIGPIPE crash mitigation in Linux
+
   fSSL := SSL_new(fSSLContext.Context);
   if fSSL = nil then
   begin
@@ -4981,9 +4989,6 @@ var
 begin
   Assert(fSSL = nil);
   Assert(fSSLContext <> nil);
-{$IF Defined(Linux) or Defined(Android)}
-  DisableSigPipe;
-{$IFEND}
   if Supports(FParent, ITaurusTLSCallbackHelper, IInterface(LHelper)) then
   begin
     LParentIO := LHelper.GetIOHandlerSelf;
@@ -5241,15 +5246,6 @@ procedure TTaurusTLSSocket.SetVerifyHostName(const Value: Boolean);
 begin
   fVerifyHostname := Value;
 end;
-
-{$IF Defined(Linux) or Defined(Android)}
-procedure TTaurusTLSSocket.DisableSigPipe;
-begin
-  sigemptyset(FSigSet);
-  sigaddset(FSigSet, SIGPIPE);
-  pthread_sigmask(SIG_BLOCK, @FSigSet, nil);
-end;
-{$IFEND}
 
 function TTaurusTLSSocket.GetSSLProtocolVersion: TTaurusTLSSSLVersion;
 begin

--- a/Source/TaurusTLSCompilerDefines.inc
+++ b/Source/TaurusTLSCompilerDefines.inc
@@ -27,6 +27,9 @@
 
 {$UNDEF STATICLOAD_OPENSSL}
 
+// Mke shure the  SIGPIPE_MASK is defined only for specific platfrom(s).
+{$UNDEF SIGPIPE_MASK}
+
 // Make sure the following are $DEFINE'd only for Delphi/C++Builder 2009 onwards
 // as specified further below.  The VCL is fully Unicode, where the 'String'
 // type maps to System.UnicodeString, not System.AnsiString anymore
@@ -1231,6 +1234,7 @@
     {$ENDIF}
   {$ENDIF}
 {$ENDIF}
+
 {$IFDEF LINUX}
   {$IFDEF LINUX64}
     {$DEFINE CPU64}
@@ -1239,8 +1243,9 @@
       {$DEFINE CPU32}
     {$ENDIF}
   {$ENDIF}
+  // enables // SIGPIPE crash mitigation in Linux
+  {$DEFINE SIGPIPE_MASK}
 {$ENDIF}
-
 {end Unix OS specific stuff}
 
 {$IFDEF DEBUG}


### PR DESCRIPTION
The SIGPIPE masking is applied only in `TTaurusTLSSocket.Accept` method to ensure that only threads managed by ServerIOHandler are masked. This avoids possible interference with the other threads in applicaion that may use different signal masks.