### PR TITLE
Add UseBidirectionalShutdown option to avoid truncated FTPS transfers

### DIFF
--- a/Source/TaurusTLS.pas
+++ b/Source/TaurusTLS.pas
@@ -487,6 +487,12 @@ const
   /// The default value for TSLLOptions.VerifyHostname property.
   /// </summary>
   DEF_VERIFY_HOSTNAME = True;
+  //20260605 xjikka
+  /// <summary>
+  /// The default value for the TTaurusTLSOptions.UseBidirectionalShutdown and
+  /// TTaurusTLSContext.UseBidirectionalShutdown properties.
+  /// </summary>
+  DEF_USE_BIDIRECTIONAL_SHUTDOWN = False;
 
 type
   /// <summary>
@@ -833,6 +839,7 @@ type
     FSecurityLevel: TTaurusTLSSecurityLevel;
     fMethod: TTaurusTLSSSLVersion;
     fVerifyHostname: Boolean;
+    fUseBidirectionalShutdown: Boolean;  //20260605 xjikka
     fVerifyDirs: String;
     fCipherList: String;
     fVerifyMode: TTaurusTLSVerifyModeSet;
@@ -963,6 +970,16 @@ type
     /// </summary>
     property VerifyHostname: Boolean read fVerifyHostname write fVerifyHostname
       default DEF_VERIFY_HOSTNAME;
+    //20260605 xjikka
+    /// <summary>
+    /// When True, the TLS connection is shut down bidirectionally - a
+    /// close_notify is sent and the peer's close_notify is awaited - instead of
+    /// a one-way shutdown. This prevents the peer from treating the data stream
+    /// as truncated (e.g. large FTPS uploads were being cut short at the end).
+    /// Default is False (one-way shutdown, the historical behaviour).
+    /// </summary>
+    property UseBidirectionalShutdown: Boolean read fUseBidirectionalShutdown
+      write fUseBidirectionalShutdown default DEF_USE_BIDIRECTIONAL_SHUTDOWN;
     /// <summary>
     /// Use the system's ROOT and CA certificate stores to verify certificates.
     /// </summary>
@@ -1024,6 +1041,7 @@ type
     fVerifyOn: Boolean;
     fSessionId: Integer;
     fVerifyHostname: Boolean;
+    fUseBidirectionalShutdown: Boolean;  //20260605 xjikka
     //20260116 xjikka:
     //  OnContextLoaderCustom allows custom TLS context initialization/loading
     //  (e.g. loading certificates/keys from TBytes, TStream, or other custom sources).
@@ -1238,6 +1256,12 @@ type
     /// </summary>
     property VerifyHostname: Boolean read fVerifyHostname write fVerifyHostname
        default DEF_VERIFY_HOSTNAME;
+    //20260605 xjikka
+    /// <summary>
+    /// Use bidirectional TLS shutdown (send close_notify and wait for peer's)
+    /// </summary>
+    property UseBidirectionalShutdown: Boolean read fUseBidirectionalShutdown
+       write fUseBidirectionalShutdown default DEF_USE_BIDIRECTIONAL_SHUTDOWN;
   /// <summary>
   ///   This event is triggered when the context is initialized and permits you
   ///   to customize the initialization behavior.
@@ -3488,6 +3512,7 @@ begin
   FSecurityLevel := DEF_SECURITY_LEVEL;
   fVerifyDepth := DEFAULT_VERIFY_DEPTH;
   fVerifyHostname := DEF_VERIFY_HOSTNAME;
+  fUseBidirectionalShutdown := DEF_USE_BIDIRECTIONAL_SHUTDOWN;
 end;
 
 procedure TTaurusTLSOptions.SetMinTLSVersion(const AValue
@@ -3515,6 +3540,7 @@ begin
     LDest.VerifyMode := VerifyMode;
     LDest.VerifyDepth := VerifyDepth;
     LDest.VerifyHostname := VerifyHostname;
+    LDest.UseBidirectionalShutdown := UseBidirectionalShutdown;
     LDest.fUseSystemRootCACertificateStore := fUseSystemRootCACertificateStore;
     LDest.VerifyDirs := VerifyDirs;
     LDest.CipherList := CipherList;
@@ -3593,6 +3619,7 @@ begin
     LUseSystemRootCACertificateStore;
   fSSLContext.VerifyDirs := SSLOptions.VerifyDirs;
   fSSLContext.VerifyHostname := LVerifyHostname;
+  fSSLContext.UseBidirectionalShutdown := SSLOptions.UseBidirectionalShutdown;
   fSSLContext.CipherList := LCipherList;
   fSSLContext.VerifyOn := Assigned(fOnVerifyCallback);
   fSSLContext.StatusInfoOn := Assigned(FOnStatusInfo);
@@ -3633,6 +3660,7 @@ begin
       LContext.UseSystemRootCACertificateStore :=
         LUseSystemRootCACertificateStore;
       LContext.VerifyHostname := LVerifyHostname;
+      LContext.UseBidirectionalShutdown := SSLOptions.UseBidirectionalShutdown;
       LContext.CipherList := LCipherList;
       LContext.VerifyOn := Assigned(fOnVerifyCallback);
       LContext.StatusInfoOn := Assigned(FOnStatusInfo);
@@ -4095,6 +4123,7 @@ begin
     fSSLContext.VerifyDepth := SSLOptions.VerifyDepth;
     fSSLContext.VerifyMode := SSLOptions.VerifyMode;
     fSSLContext.VerifyHostname := SSLOptions.VerifyHostname;
+    fSSLContext.UseBidirectionalShutdown := SSLOptions.UseBidirectionalShutdown;
     // fSSLContext.fVerifyFile := SSLOptions.fVerifyFile;
     fSSLContext.UseSystemRootCACertificateStore :=
       SSLOptions.UseSystemRootCACertificateStore;
@@ -4900,7 +4929,14 @@ begin
       end;
     }
     // SSL_set_shutdown(fSSL, SSL_SENT_SHUTDOWN);
-    SSL_shutdown(fSSL);  //PALOFF - Functions called as procedures
+    //20260605 xjikka - optional bidirectional shutdown (see UseBidirectionalShutdown)
+    if (fSSLContext <> nil) and fSSLContext.UseBidirectionalShutdown then begin
+      // if SSL_shutdown() returns 0 a "close notify" was sent; call it again to
+      // receive the peer's "close notify" in response (bidirectional shutdown).
+      if SSL_shutdown(fSSL) = 0 then SSL_shutdown(fSSL);  //PALOFF - Functions called as procedures
+    end else begin
+      SSL_shutdown(fSSL);  //PALOFF - Functions called as procedures
+    end;
     SSL_free(fSSL);
     fSSL := nil;
   end;


### PR DESCRIPTION
TTaurusTLSSocket.Destroy did a single one-way SSL_shutdown(): it sends a close_notify but does not wait for the peer's. On large FTPS uploads the server then treats the data stream as truncated and the stored file is cut short at the end ("Failure reading network stream").

Add a UseBidirectionalShutdown property (on TTaurusTLSOptions and TTaurusTLSContext, default False = the previous one-way behaviour). When True, Destroy performs a bidirectional shutdown - a second SSL_shutdown() to receive the peer's close_notify. The option is propagated Options -> Context for the client, server and per-SNI-certificate contexts, and copied on Assign so cloned handlers (e.g. the FTP data channel) inherit it.