### PR TITLE
Definition correction: SSL_CTX_set_tlsext_servername_callback_cb

### DIFF
--- a/Source/TaurusTLS.pas
+++ b/Source/TaurusTLS.pas
@@ -2999,7 +2999,7 @@ begin
   end;
 end;
 
-function g_tlsext_SNI_callback(SSL: PSSL; alert: PIdC_INT; arg: Pointer) //FI:O804 //surpress method parameter is declared but never used.
+function g_tlsext_SNI_callback(SSL: PSSL; var alert: TIdC_INT; arg: Pointer) //FI:O804 //surpress method parameter is declared but never used.
   : TIdC_INT; cdecl;
 var
   LErr: Integer;   //PALOFF

--- a/Source/TaurusTLSHeaders_tls1.pas
+++ b/Source/TaurusTLSHeaders_tls1.pas
@@ -1309,7 +1309,7 @@ var
 {$ENDIF}
 
 type
-  SSL_CTX_set_tlsext_servername_callback_cb = function (ssl : PSSL; alert : PIdC_INT; arg : Pointer) : TIdC_INT; cdecl;
+  SSL_CTX_set_tlsext_servername_callback_cb = function (ssl : PSSL; var alert : TIdC_INT; arg : Pointer) : TIdC_INT; cdecl;
 
 function SSL_CTX_set_tlsext_servername_callback(ctx : PSSL_CTX; cb : SSL_CTX_set_tlsext_servername_callback_cb) : TIdC_LONG;
 function SSL_CTX_set_tlsext_servername_arg(ctx : PSSL_CTX; arg : Pointer)  : TIdC_LONG;


### PR DESCRIPTION
The `alert` parameter in the `SSL_CTX_set_tlsext_servername_callback_cb` callback must be `var` parameter of `TIdC_INT` type instead of `pointer` to `TIdC_INT`.