### PR TITLE
Corrected callback type Tmsg_callback to avoid AV

### DIFF
--- a/Source/TaurusTLS.pas
+++ b/Source/TaurusTLS.pas
@@ -2938,8 +2938,8 @@ begin
   end;
 end;
 
-procedure g_MsgCallback(write_p, Version, content_type: TIdC_INT; const buf;
-  len: TIdC_SIZET; SSL: PSSL; arg: Pointer)cdecl;
+procedure g_MsgCallback(write_p, Version, content_type: TIdC_INT;
+  const buf: pointer; len: TIdC_SIZET; SSL: PSSL; arg: Pointer) cdecl;
 var
   LErr: Integer;   //PALOFF
   LHelper: ITaurusTLSCallbackHelper;
@@ -2971,7 +2971,10 @@ begin
         var
           LBytes: TIdBytes;
 {$ENDIF}
-        LBytes := TaurusTLSRawToBytes(buf, len);
+        if buf <> nil then
+          LBytes := TaurusTLSRawToBytes(buf^, len)
+        else
+          lBytes := [];
         case Version of
           SSL3_VERSION:
             LVer := verSSL3Header;

--- a/Source/TaurusTLSHeaders_ssl.pas
+++ b/Source/TaurusTLSHeaders_ssl.pas
@@ -1259,7 +1259,8 @@ type
 
   TSSL_CTX_set_verify_callback = function (ok : TIdC_INT; ctx : PX509_STORE_CTX) : TIdC_INT; cdecl;
 
-  Tmsg_callback = procedure(write_p, version, content_type : TIdC_INT; const buf; len : TIdC_SIZET; ssl : PSSL; arg : Pointer); cdecl;
+  Tmsg_callback = procedure(write_p, version, content_type : TIdC_INT;
+    const buf: Pointer; len : TIdC_SIZET; ssl : PSSL; arg : Pointer); cdecl;
 
     { The EXTERNALSYM directive is ignored by FPC, however, it is used by Delphi as follows:
 		


### PR DESCRIPTION
The `Tmsg_callback` used untyped parameter `const buf`. The OpenSSL declared such parameter as `const void *buf`. However, the value of this parameter can be `NULL`. The `NULL` value in Pascal untyped `const` parameter leads AV when parameter value is accessed. (I.e. compiler dereferences the `nil` value).

This fix changes:
- the `const buf` parameter to `buf: Pointer` in the `Tmsg_callback`
- modifies procedure parameters in the `g_MsgCallback` 
- makes the safe `LBytes` building from the `buf` in the procedure `g_MsgCallback` 