### PR TITLE
cleaned up dpm dspec

### DIFF
--- a/TaurusTLS_Developers.TaurusTLS.dspec
+++ b/TaurusTLS_Developers.TaurusTLS.dspec
@@ -113,6 +113,8 @@ templates:
       - src: ./DifferencesBetweenIndyOpenSSLAndTaurusTLS.md
       - src: ./What_needs_to_be_done.MD
       - src: ./Source/**.*
+        exclude:
+          - '*.dcu'
       - src: ./Packages/$packageSource$/*.dpk
       - src: ./Packages/$packageSource$/*.dproj
       - src: ./Help/chm/TaurusForIndy290All.chm

--- a/TaurusTLS_Developers.TaurusTLS.dspec
+++ b/TaurusTLS_Developers.TaurusTLS.dspec
@@ -112,7 +112,7 @@ templates:
       - src: ./Modified_BSD_LICENSE.md
       - src: ./DifferencesBetweenIndyOpenSSLAndTaurusTLS.md
       - src: ./What_needs_to_be_done.MD
-      - src: ./Source/**.*
+      - src: ./Source/*.*
         exclude:
           - '*.dcu'
       - src: ./Packages/$packageSource$/*.dpk

--- a/TaurusTLS_Developers.TaurusTLS.dspec
+++ b/TaurusTLS_Developers.TaurusTLS.dspec
@@ -112,12 +112,20 @@ templates:
       - src: ./Modified_BSD_LICENSE.md
       - src: ./DifferencesBetweenIndyOpenSSLAndTaurusTLS.md
       - src: ./What_needs_to_be_done.MD
-      - src: ./Source/*.*
+      - src: ./Source/*.inc
+      - src: ./Source/*.pas
         exclude:
           - '*.dcu'
+      - src: ./Source/*.dcr
       - src: ./Packages/$packageSource$/*.dpk
       - src: ./Packages/$packageSource$/*.dproj
       - src: ./Help/chm/TaurusForIndy290All.chm
+      - src: /demos/**.*
+        exclude:
+          - '*.dcu'
+          - '*.obj'
+          - '*.exe'
+          - ''
     build:
       - project: ./Packages/$packageSource$/TaurusTLS_RT.dproj
     design:

--- a/TaurusTLS_Developers.TaurusTLS.dspec
+++ b/TaurusTLS_Developers.TaurusTLS.dspec
@@ -2,9 +2,9 @@
 min dpm client version: 1.0.0
 metadata:
   id: TaurusTLS_Developers.TaurusTLS
-  version: 1.0.8
+  version: 1.0.9
   description: TaurusTLS provides OpenSSL 3.x and 4.x support for Indy - Internet Direct
-  icon: ..\..\TaurusTLS\logo\bullhead.png
+  icon: logo\bullhead.png
   authors:
     - TaurusTLS Developers
   projectUrl: https://github.com/TaurusTLS-Developers/TaurusTLS
@@ -14,6 +14,7 @@ metadata:
   tags:
     - indy
     - TLS
+    - OpenSSL
   readme: README.md
 variables:
   packagesource: d$compilerCodeName$
@@ -111,122 +112,9 @@ templates:
       - src: ./Modified_BSD_LICENSE.md
       - src: ./DifferencesBetweenIndyOpenSSLAndTaurusTLS.md
       - src: ./What_needs_to_be_done.MD
-      - src: ./Source/TaurusTLS.pas
-      - src: ./Source/TaurusTLSConsts.pas
-      - src: ./Source/TaurusTLSExceptionHandlers.pas
-      - src: ./Source/TaurusTLSFIPS.pas
-      - src: ./Source/TaurusTLSHeaders_aes.pas
-      - src: ./Source/TaurusTLSHeaders_asn1.pas
-      - src: ./Source/TaurusTLSHeaders_asn1err.pas
-      - src: ./Source/TaurusTLSHeaders_asn1t.pas
-      - src: ./Source/TaurusTLSHeaders_asn1_mac.pas
-      - src: ./Source/TaurusTLSHeaders_async.pas
-      - src: ./Source/TaurusTLSHeaders_asyncerr.pas
-      - src: ./Source/TaurusTLSHeaders_bio.pas
-      - src: ./Source/TaurusTLSHeaders_bioerr.pas
-      - src: ./Source/TaurusTLSHeaders_blowfish.pas
-      - src: ./Source/TaurusTLSHeaders_bn.pas
-      - src: ./Source/TaurusTLSHeaders_bnerr.pas
-      - src: ./Source/TaurusTLSHeaders_buffer.pas
-      - src: ./Source/TaurusTLSHeaders_buffererr.pas
-      - src: ./Source/TaurusTLSHeaders_camellia.pas
-      - src: ./Source/TaurusTLSHeaders_cast.pas
-      - src: ./Source/TaurusTLSHeaders_cmac.pas
-      - src: ./Source/TaurusTLSHeaders_cms.pas
-      - src: ./Source/TaurusTLSHeaders_cmserr.pas
-      - src: ./Source/TaurusTLSHeaders_comp.pas
-      - src: ./Source/TaurusTLSHeaders_comperr.pas
-      - src: ./Source/TaurusTLSHeaders_conf.pas
-      - src: ./Source/TaurusTLSHeaders_conferr.pas
-      - src: ./Source/TaurusTLSHeaders_conf_api.pas
-      - src: ./Source/TaurusTLSHeaders_core.pas
-      - src: ./Source/TaurusTLSHeaders_crypto.pas
-      - src: ./Source/TaurusTLSHeaders_cryptoerr.pas
-      - src: ./Source/TaurusTLSHeaders_crypto_decoder.pas
-      - src: ./Source/TaurusTLSHeaders_crypto_decodererr.pas
-      - src: ./Source/TaurusTLSHeaders_crypto_encoder.pas
-      - src: ./Source/TaurusTLSHeaders_crypto_encodererr.pas
-      - src: ./Source/TaurusTLSHeaders_ct.pas
-      - src: ./Source/TaurusTLSHeaders_cterr.pas
-      - src: ./Source/TaurusTLSHeaders_des.pas
-      - src: ./Source/TaurusTLSHeaders_dh.pas
-      - src: ./Source/TaurusTLSHeaders_dherr.pas
-      - src: ./Source/TaurusTLSHeaders_dsa.pas
-      - src: ./Source/TaurusTLSHeaders_dsaerr.pas
-      - src: ./Source/TaurusTLSHeaders_ebcdic.pas
-      - src: ./Source/TaurusTLSHeaders_ec.pas
-      - src: ./Source/TaurusTLSHeaders_ecerr.pas
-      - src: ./Source/TaurusTLSHeaders_ech.pas
-      - src: ./Source/TaurusTLSHeaders_engine.pas
-      - src: ./Source/TaurusTLSHeaders_engineerr.pas
-      - src: ./Source/TaurusTLSHeaders_err.pas
-      - src: ./Source/TaurusTLSHeaders_evp.pas
-      - src: ./Source/TaurusTLSHeaders_evperr.pas
-      - src: ./Source/TaurusTLSHeaders_hmac.pas
-      - src: ./Source/TaurusTLSHeaders_hpke.pas
-      - src: ./Source/TaurusTLSHeaders_idea.pas
-      - src: ./Source/TaurusTLSHeaders_kdferr.pas
-      - src: ./Source/TaurusTLSHeaders_objects.pas
-      - src: ./Source/TaurusTLSHeaders_objectserr.pas
-      - src: ./Source/TaurusTLSHeaders_obj_mac.pas
-      - src: ./Source/TaurusTLSHeaders_ocsperr.pas
-      - src: ./Source/TaurusTLSHeaders_openssl_decoder.pas
-      - src: ./Source/TaurusTLSHeaders_openssl_decodererr.pas
-      - src: ./Source/TaurusTLSHeaders_openssl_encoder.pas
-      - src: ./Source/TaurusTLSHeaders_openssl_encoderer.pas
-      - src: ./Source/TaurusTLSHeaders_params.pas
-      - src: ./Source/TaurusTLSHeaders_pem.pas
-      - src: ./Source/TaurusTLSHeaders_pemerr.pas
-      - src: ./Source/TaurusTLSHeaders_pkcs12.pas
-      - src: ./Source/TaurusTLSHeaders_pkcs7.pas
-      - src: ./Source/TaurusTLSHeaders_pkcs7err.pas
-      - src: ./Source/TaurusTLSHeaders_provider.pas
-      - src: ./Source/TaurusTLSHeaders_quic.pas
-      - src: ./Source/TaurusTLSHeaders_rand.pas
-      - src: ./Source/TaurusTLSHeaders_randerr.pas
-      - src: ./Source/TaurusTLSHeaders_rc4.pas
-      - src: ./Source/TaurusTLSHeaders_rsa.pas
-      - src: ./Source/TaurusTLSHeaders_rsaerr.pas
-      - src: ./Source/TaurusTLSHeaders_safestack.pas
-      - src: ./Source/TaurusTLSHeaders_sha.pas
-      - src: ./Source/TaurusTLSHeaders_srtp.pas
-      - src: ./Source/TaurusTLSHeaders_ssl.pas
-      - src: ./Source/TaurusTLSHeaders_ssl3.pas
-      - src: ./Source/TaurusTLSHeaders_sslerr.pas
-      - src: ./Source/TaurusTLSHeaders_stack.pas
-      - src: ./Source/TaurusTLSHeaders_store.pas
-      - src: ./Source/TaurusTLSHeaders_storeerr.pas
-      - src: ./Source/TaurusTLSHeaders_tls1.pas
-      - src: ./Source/TaurusTLSHeaders_ts.pas
-      - src: ./Source/TaurusTLSHeaders_tserr.pas
-      - src: ./Source/TaurusTLSHeaders_txt_db.pas
-      - src: ./Source/TaurusTLSHeaders_types.pas
-      - src: ./Source/TaurusTLSHeaders_ui.pas
-      - src: ./Source/TaurusTLSHeaders_uierr.pas
-      - src: ./Source/TaurusTLSHeaders_whrlpool.pas
-      - src: ./Source/TaurusTLSHeaders_x509.pas
-      - src: ./Source/TaurusTLSHeaders_x509err.pas
-      - src: ./Source/TaurusTLSHeaders_x509v3.pas
-      - src: ./Source/TaurusTLSHeaders_x509_vfy.pas
-      - src: ./Source/TaurusTLSLoader.pas
-      - src: ./Source/TaurusTLS_Files.pas
-      - src: ./Source/TaurusTLS_NTLM.pas
-      - src: ./Source/TaurusTLS_ResourceStrings.pas
-      - src: ./Source/TaurusTLS_Unicode_Log.pas
-      - src: ./Source/TaurusTLS_Utils.pas
-      - src: ./Source/TaurusTLS_X509.pas
-      - src: ./Source/TaurusTLS_Dsn_AboutDlg.pas
-      - src: ./Source/TaurusTLS_Dsn_ComponentEditor.pas
-      - src: ./Source/TaurusTLS_Dsn_Register.pas
-      - src: ./Source/TaurusTLS_Dsn_ResourceStrings.pas
-      - src: ./Source/**.dcr
-      - src: ./Source/**.lrs      
-      - src: ./Source/**.inc
+      - src: ./Source/**.*
       - src: ./Packages/$packageSource$/*.dpk
       - src: ./Packages/$packageSource$/*.dproj
-      - src: ./Demos/FTPServer/*.*
-      - src: ./Demos/TaurusFTPConsole/*.*
-      - src: ./Demos/TaurusHTTPServer/*.*
       - src: ./Help/chm/TaurusForIndy290All.chm
     build:
       - project: ./Packages/$packageSource$/TaurusTLS_RT.dproj


### PR DESCRIPTION
Hi J

I cleaned up the dspec and tested it here. I removed things that do not need to be in the package, such as demos, changed the source filespec to use wildcards. I tested that it compiles during install.

Note that I bumped the version to 1.0.9 as package versions are immutable (cannot republish the same version). Please pack and upload again. I another package author told me they are waiting on this so they can publish a package with a dependency on taurus. 