### PR TITLE
Minor code corrections

### DIFF
--- a/Source/TaurusTLSHeaders_types.pas
+++ b/Source/TaurusTLSHeaders_types.pas
@@ -66,8 +66,6 @@ interface
 (*$HPPEMIT '  typedef ASN1_OBJECT* PASN1_OBJECT;'*)
 (*$HPPEMIT '  struct ASN1_TIME;'*)
 (*$HPPEMIT '  typedef ASN1_TIME* PASN1_TIME;'*)
-(*$HPPEMIT '  struct ASN1_OCTET_STRING;'*)
-(*$HPPEMIT '  typedef ASN1_OCTET_STRING* PASN1_OCTET_STRING;'*)
 (*$HPPEMIT '	struct SSL;'*)
 (*$HPPEMIT '	typedef SSL* PSSL;'*)
 (*$HPPEMIT '	struct SSL_CTX;'*)

--- a/Source/TaurusTLSHeaders_x509.pas
+++ b/Source/TaurusTLSHeaders_x509.pas
@@ -1263,7 +1263,7 @@ var
   {$EXTERNALSYM sk_X509_ATTRIBUTE_find}
   function sk_X509_ATTRIBUTE_find (sk : PSTACK_OF_X509_ATTRIBUTE; _val : PX509_ATTRIBUTE) : TIdC_INT cdecl; external CLibCrypto name 'OPENSSL_sk_find';
   {$EXTERNALSYM sk_X509_ATTRIBUTE_pop_free}
-  procedure sk_X509_ATTRIBUTE_pop_free (sk : PSTACK_OF_X509_ATTRIBUTE; fun88c: TOPENSSL_sk_freefunc) cdecl; external CLibCrypto name 'OPENSSL_sk_pop_free';
+  procedure sk_X509_ATTRIBUTE_pop_free (sk : PSTACK_OF_X509_ATTRIBUTE; func: TOPENSSL_sk_freefunc) cdecl; external CLibCrypto name 'OPENSSL_sk_pop_free';
 {$ENDIF}
 {/helper_functions}
 


### PR DESCRIPTION
The last commit for #241 introduced a typo on line 1266 of Source\TaurusTLSHeaders_x509.pas.  `func` appears to have been accidentally renamed to `fun88c`.

When reviewing the fix for #241, I noticed duplicate HPPEMIT lines for `ASN1_OCTET_STRING` and `PASN1_OCTET_STRING`.

This commit fixes both of these minor problems.